### PR TITLE
修正 CronTab 重复添加问题

### DIFF
--- a/Hawkeye.py
+++ b/Hawkeye.py
@@ -268,8 +268,8 @@ def write_cron(time, page):
         cron_command = '{0}/venv/bin/python {0}/spider.py 1 {1}'.format(
             base_path, page)
         my_user_cron = CronTab(user=True)
-        if list(my_user_cron.find_command('Hawkeye')):
-            for cron in my_user_cron.find_command('Hawkeye'):
+        if list(my_user_cron.find_comment('Hawkeye')):
+            for cron in my_user_cron.find_comment('Hawkeye'):
                 cron.delete()
         job = my_user_cron.new(command=cron_command)
         job.setall('*/{} * * * *'.format(time))
@@ -283,10 +283,10 @@ def write_cron(time, page):
 
 def read_cron():
     user_cron = CronTab(user=True)
-    if list(user_cron.find_command('Hawkeye')):
-        page = int(list(user_cron.find_command('Hawkeye'))
+    if list(user_cron.find_comment('Hawkeye')):
+        page = int(list(user_cron.find_comment('Hawkeye'))
                    [0].command.split(' ')[-1]) - 1
-        every = int(str(list(user_cron.find_command('Hawkeye'))
+        every = int(str(list(user_cron.find_comment('Hawkeye'))
                         [0].minutes).replace('*/', ''))
         return {'every': every, 'page': page}
     else:


### PR DESCRIPTION
crontab 内容为：`*/5 * * * * xxxx/venv/bin/python xxxx/hawkeye/spider.py 1 2 # Hawkeye`

使用 find_command  找不到记录会一直重复添加，改为 find_comment 修复该问题
