### PR TITLE
ImportError: cannot import name 'Feature' from 'setuptools'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN add-apt-repository -y "deb http://openresty.org/package/debian stretch openr
 RUN apt-get update
 RUN apt-get install -y openresty
 COPY ./deploy /Hawkeye/deploy
+RUN RUN pip install --upgrade pip setuptools==45.2.0
 RUN pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -r /Hawkeye/deploy/pyenv/requirements.txt -U
 RUN cp /Hawkeye/deploy/nginx/*.conf /usr/local/openresty/nginx/conf/
 RUN cp /Hawkeye/deploy/supervisor/*.conf /etc/supervisor/conf.d/


### PR DESCRIPTION

解决"ImportError: cannot import name 'Feature' from 'setuptools'"
查阅相关文档发现是setuptool版本的问题，python3源中的setuptools已经升级到46以上。所以导致pip安装失败
更新setuptools版本